### PR TITLE
Use Java 21 in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,4 +37,9 @@ jobs:
       otherConsoleOptions: '/collect:"Code Coverage;Format=Xml"' # Necessary to have an XML coverage report
       codeCoverageEnabled: true
       testRunTitle: 'Run tests'
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: '21'
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
   - task: SonarCloudAnalyze@1


### PR DESCRIPTION
## Summary
- run the Sonar analysis step with Java 21

## Validation
- Parsed the changed YAML with Python
- git diff --check

The current Sonar scanner no longer supports Java 17.

## Fork PR CI note

The Azure pipeline check is expected to fail for this PR because it originates from a fork. Azure DevOps skips `SonarCloudPrepare`, which references the protected SonarCloud service endpoint, so `SonarCloudAnalyze` subsequently reports that its variables are missing. After merge, the `main` build can access the service connection and should validate the Java 21 change successfully.